### PR TITLE
Update GitHub issue scraper with CLI and pagination

### DIFF
--- a/github_issues.py
+++ b/github_issues.py
@@ -1,6 +1,8 @@
 import requests
 import json
 import logging
+import os
+import argparse
 from pydantic import BaseModel
 from typing import List
 
@@ -17,12 +19,15 @@ class GitHubScraper:
         self.headers = {"Authorization": f"Bearer {token}"}
         self.output_file = "github_issues.json"
 
-    def fetch_issues(self, repo: str, pages: int = 5) -> List[GitHubData]:
+    def fetch_issues(self, repo: str, max_pages: int = 5) -> List[GitHubData]:
         data = []
-        for page in range(1, pages + 1):
+        url = f"{self.base_url}/repos/{repo}/issues"
+        params = {"state": "all", "per_page": 100}
+        page = 0
+
+        while url and page < max_pages:
             try:
-                params = {"state": "all", "page": page, "per_page": 100}
-                response = requests.get(f"{self.base_url}/repos/{repo}/issues", headers=self.headers, params=params)
+                response = requests.get(url, headers=self.headers, params=params)
                 response.raise_for_status()
                 items = response.json()
                 for item in items:
@@ -38,7 +43,21 @@ class GitHubScraper:
                         }
                     ))
             except Exception as e:
-                logging.error(f"Erro ao coletar issues de {repo}, página {page}: {e}")
+                logging.error(f"Erro ao coletar issues de {repo}, página {page + 1}: {e}")
+                break
+
+            link_header = response.headers.get("Link", "")
+            next_url = None
+            if link_header:
+                for part in link_header.split(','):
+                    if 'rel="next"' in part:
+                        next_url = part[part.find('<') + 1:part.find('>')]
+                        break
+
+            url = next_url
+            params = None  # next_url já possui os parâmetros
+            page += 1
+
         return data
 
     def save_to_json(self, data: List[GitHubData]):
@@ -46,7 +65,16 @@ class GitHubScraper:
             json.dump([d.dict() for d in data], f, indent=2, ensure_ascii=False)
         logging.info(f"Dados salvos em {self.output_file}")
 
-# Exemplo de uso
-scraper = GitHubScraper(token="SEU_TOKEN")
-data = scraper.fetch_issues(repo="kubernetes/kubernetes", pages=5)
-scraper.save_to_json(data)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Coleta issues de um repositório GitHub")
+    parser.add_argument("--repo", required=True, help="Repositório no formato owner/repo")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN"), help="Token de acesso do GitHub")
+    parser.add_argument("--max-pages", type=int, default=5, help="Número máximo de páginas a coletar")
+    args = parser.parse_args()
+
+    if not args.token:
+        parser.error("Token não informado e GITHUB_TOKEN ausente")
+
+    scraper = GitHubScraper(token=args.token)
+    data = scraper.fetch_issues(repo=args.repo, max_pages=args.max_pages)
+    scraper.save_to_json(data)


### PR DESCRIPTION
## Summary
- handle pagination by following `Link` header
- add CLI arguments for repo, token and maximum pages
- read token from `GITHUB_TOKEN` if the option is omitted
- move usage example to `if __name__ == "__main__"`

## Testing
- `python -m py_compile github_issues.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684f05a9ffdc8320b16585b0f1985535