### PR TITLE
Improve GitHub scrapers

### DIFF
--- a/github_comments_data.py
+++ b/github_comments_data.py
@@ -1,8 +1,11 @@
-import requests
+import argparse
 import json
 import logging
+import os
+from typing import List, Optional
+
+import requests
 from pydantic import BaseModel
-from typing import List
 
 logging.basicConfig(level=logging.INFO)
 
@@ -17,33 +20,46 @@ class GitHubCommentScraper:
         self.headers = {"Authorization": f"Bearer {token}"}
         self.output_file = "github_comments_data.json"
 
-    def fetch_comments(self, repo: str, pages: int = 5) -> List[GitHubCommentData]:
-        data = []
-        for page in range(1, pages + 1):
+    def fetch_comments(self, repo: str, max_pages: Optional[int] = None) -> List[GitHubCommentData]:
+        data: List[GitHubCommentData] = []
+        url = f"{self.base_url}/repos/{repo}/issues/comments"
+        params = {"per_page": 100}
+        page = 0
+        while url:
+            if max_pages is not None and page >= max_pages:
+                break
             try:
-                # Coletar comentários de issues
-                params = {"page": page, "per_page": 100}
-                response = requests.get(
-                    f"{self.base_url}/repos/{repo}/issues/comments",
-                    headers=self.headers,
-                    params=params
-                )
+                response = requests.get(url, headers=self.headers, params=params)
                 response.raise_for_status()
                 items = response.json()
                 for item in items:
-                    data.append(GitHubCommentData(
-                        id=str(item["id"]),
-                        content=item["body"],
-                        metadata={
-                            "url": item["html_url"],
-                            "timestamp": item["created_at"],
-                            "tags": ["comment", repo],
-                            "language": "english",
-                            "type": "comment"
-                        }
-                    ))
+                    data.append(
+                        GitHubCommentData(
+                            id=str(item["id"]),
+                            content=item.get("body", ""),
+                            metadata={
+                                "url": item.get("html_url", ""),
+                                "timestamp": item.get("created_at", ""),
+                                "tags": ["comment", repo],
+                                "language": "english",
+                                "type": "comment",
+                            },
+                        )
+                    )
+                page += 1
+                next_url = None
+                links = requests.utils.parse_header_links(
+                    response.headers.get("Link", "")
+                )
+                for link in links:
+                    if link.get("rel") == "next":
+                        next_url = link.get("url")
+                        break
+                url = next_url
+                params = None  # next_url already contains query params
             except Exception as e:
                 logging.error(f"Erro ao coletar comentários de {repo}, página {page}: {e}")
+                break
         return data
 
     def save_to_json(self, data: List[GitHubCommentData]):
@@ -51,7 +67,20 @@ class GitHubCommentScraper:
             json.dump([d.dict() for d in data], f, indent=2, ensure_ascii=False)
         logging.info(f"Dados salvos em {self.output_file}")
 
-# Exemplo de uso
-scraper = GitHubCommentScraper(token="SEU_TOKEN")
-data = scraper.fetch_comments(repo="kubernetes/kubernetes", pages=5)
-scraper.save_to_json(data)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scrape GitHub issue comments")
+    parser.add_argument("--repo", default=os.getenv("GITHUB_REPO"), help="owner/repo")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN"), help="GitHub token")
+    parser.add_argument("--max-pages", type=int, default=None, help="Stop after N pages (optional)")
+    args = parser.parse_args()
+
+    if not args.repo or not args.token:
+        parser.error("Repository and token são obrigatórios via argumento ou variável de ambiente")
+
+    scraper = GitHubCommentScraper(token=args.token)
+    data = scraper.fetch_comments(repo=args.repo, max_pages=args.max_pages)
+    scraper.save_to_json(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/github_issues.py
+++ b/github_issues.py
@@ -1,8 +1,11 @@
-import requests
+import argparse
 import json
 import logging
+import os
+from typing import List, Optional
+
+import requests
 from pydantic import BaseModel
-from typing import List
 
 logging.basicConfig(level=logging.INFO)
 
@@ -17,28 +20,46 @@ class GitHubScraper:
         self.headers = {"Authorization": f"Bearer {token}"}
         self.output_file = "github_issues.json"
 
-    def fetch_issues(self, repo: str, pages: int = 5) -> List[GitHubData]:
-        data = []
-        for page in range(1, pages + 1):
+    def fetch_issues(self, repo: str, max_pages: Optional[int] = None) -> List[GitHubData]:
+        data: List[GitHubData] = []
+        url = f"{self.base_url}/repos/{repo}/issues"
+        params = {"state": "all", "per_page": 100}
+        page = 0
+        while url:
+            if max_pages is not None and page >= max_pages:
+                break
             try:
-                params = {"state": "all", "page": page, "per_page": 100}
-                response = requests.get(f"{self.base_url}/repos/{repo}/issues", headers=self.headers, params=params)
+                response = requests.get(url, headers=self.headers, params=params)
                 response.raise_for_status()
                 items = response.json()
                 for item in items:
-                    data.append(GitHubData(
-                        id=str(item["id"]),
-                        content=item["title"] + "\n" + item.get("body", ""),
-                        metadata={
-                            "url": item["html_url"],
-                            "timestamp": item["created_at"],
-                            "tags": item.get("labels", []),
-                            "language": "unknown",
-                            "type": "issue"
-                        }
-                    ))
+                    data.append(
+                        GitHubData(
+                            id=str(item.get("id")),
+                            content=item.get("title", "") + "\n" + item.get("body", ""),
+                            metadata={
+                                "url": item.get("html_url", ""),
+                                "timestamp": item.get("created_at", ""),
+                                "tags": item.get("labels", []),
+                                "language": "unknown",
+                                "type": "issue",
+                            },
+                        )
+                    )
+                page += 1
+                next_url = None
+                links = requests.utils.parse_header_links(
+                    response.headers.get("Link", "")
+                )
+                for link in links:
+                    if link.get("rel") == "next":
+                        next_url = link.get("url")
+                        break
+                url = next_url
+                params = None  # next_url already contains query params
             except Exception as e:
                 logging.error(f"Erro ao coletar issues de {repo}, página {page}: {e}")
+                break
         return data
 
     def save_to_json(self, data: List[GitHubData]):
@@ -46,7 +67,20 @@ class GitHubScraper:
             json.dump([d.dict() for d in data], f, indent=2, ensure_ascii=False)
         logging.info(f"Dados salvos em {self.output_file}")
 
-# Exemplo de uso
-scraper = GitHubScraper(token="SEU_TOKEN")
-data = scraper.fetch_issues(repo="kubernetes/kubernetes", pages=5)
-scraper.save_to_json(data)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scrape GitHub issues")
+    parser.add_argument("--repo", default=os.getenv("GITHUB_REPO"), help="owner/repo")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN"), help="GitHub token")
+    parser.add_argument("--max-pages", type=int, default=None, help="Stop after N pages (optional)")
+    args = parser.parse_args()
+
+    if not args.repo or not args.token:
+        parser.error("Repository and token são obrigatórios via argumento ou variável de ambiente")
+
+    scraper = GitHubScraper(token=args.token)
+    data = scraper.fetch_issues(repo=args.repo, max_pages=args.max_pages)
+    scraper.save_to_json(data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI argument parsing to GitHub scrapers
- paginate `issues` and `comments` using the `Link` header
- wrap example usage with `if __name__ == "__main__"`

## Testing
- `python -m py_compile github_comments_data.py github_issues.py`

------
https://chatgpt.com/codex/tasks/task_e_684f05ac20208320ba7fe7c51bdb3d28