### PR TITLE
Update GitHub docs scraper

### DIFF
--- a/github_wiki_data.py
+++ b/github_wiki_data.py
@@ -1,8 +1,11 @@
-import requests
+import argparse
 import json
 import logging
-from pydantic import BaseModel
+import os
 from typing import List
+
+import requests
+from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
 
@@ -12,38 +15,46 @@ class GitHubWikiData(BaseModel):
     metadata: dict
 
 class GitHubWikiScraper:
-    def __init__(self, token: str):
+    def __init__(self, token: str | None = None):
         self.base_url = "https://api.github.com"
-        self.headers = {"Authorization": f"Bearer {token}"}
+        self.headers = {"Authorization": f"Bearer {token}"} if token else {}
         self.output_file = "github_wiki_data.json"
 
     def fetch_wiki(self, repo: str) -> List[GitHubWikiData]:
-        data = []
-        try:
-            # Buscar arquivos do repositório (ex.: docs/, README.md, CONTRIBUTING.md)
-            response = requests.get(
-                f"{self.base_url}/repos/{repo}/contents/docs",
-                headers=self.headers
-            )
-            response.raise_for_status()
-            files = response.json()
-            for file in files:
-                if file["name"].endswith((".md", ".rst")):
-                    file_content = requests.get(file["download_url"]).text
-                    data.append(GitHubWikiData(
-                        id=file["sha"],
-                        content=file_content,
-                        metadata={
-                            "url": file["html_url"],
-                            "timestamp": file["last_modified"],
-                            "tags": [repo, file["name"]],
-                            "language": "markdown" if file["name"].endswith(".md") else "rst",
-                            "type": self.classify_document(file["name"], file_content)
-                        }
-                    ))
-        except Exception as e:
-            logging.error(f"Erro ao coletar wiki de {repo}: {e}")
+        data: List[GitHubWikiData] = []
+
+        def recurse(path: str = ""):
+            url = f"{self.base_url}/repos/{repo}/contents/{path}".rstrip("/")
+            try:
+                response = requests.get(url, headers=self.headers)
+                response.raise_for_status()
+                items = response.json()
+                if isinstance(items, dict) and items.get("type") == "file":
+                    items = [items]
+                for item in items:
+                    if item["type"] == "dir":
+                        recurse(item["path"])
+                    elif item["type"] == "file" and item["name"].lower().endswith((".md", ".rst")):
+                        file_content = requests.get(item["download_url"]).text
+                        data.append(
+                            GitHubWikiData(
+                                id=item["sha"],
+                                content=file_content,
+                                metadata={
+                                    "url": item["html_url"],
+                                    "path": item["path"],
+                                    "tags": [repo, item["name"]],
+                                    "language": "markdown" if item["name"].lower().endswith(".md") else "rst",
+                                    "type": self.classify_document(item["name"], file_content),
+                                },
+                            )
+                        )
+            except Exception as e:
+                logging.error(f"Erro ao coletar arquivos em {path}: {e}")
+
+        recurse("")
         return data
+
 
     def classify_document(self, filename: str, content: str) -> str:
         filename = filename.lower()
@@ -58,17 +69,17 @@ class GitHubWikiScraper:
         return "documentation"
 
     def save_to_json(self, data: List[GitHubWikiData]):
-        output = {
-            "source": "github_wiki",
-            "category": "documentacao_tecnica",
-            "document_type": "mixed",
-            "data": [d.dict() for d in data]
-        }
+        output = {"data": [d.dict() for d in data]}
         with open(self.output_file, "w", encoding="utf-8") as f:
             json.dump(output, f, indent=2, ensure_ascii=False)
         logging.info(f"Dados salvos em {self.output_file}")
 
-# Exemplo de uso
-scraper = GitHubWikiScraper(token="SEU_TOKEN")
-data = scraper.fetch_wiki(repo="kubernetes/website")
-scraper.save_to_json(data)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Coleta arquivos de documentação do GitHub")
+    parser.add_argument("--repo", required=True, help="repositório no formato owner/name")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN"), help="token de acesso opcional")
+    args = parser.parse_args()
+
+    scraper = GitHubWikiScraper(token=args.token)
+    data = scraper.fetch_wiki(repo=args.repo)
+    scraper.save_to_json(data)


### PR DESCRIPTION
## Summary
- enable recursive scraping of GitHub repository documentation
- allow repository and token to be passed via CLI
- load token from `GITHUB_TOKEN` environment variable if not provided
- classify markdown/rst files and store in a JSON object with `data` field
- wrap execution in a main block

## Testing
- `python3 github_wiki_data.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684f05aed0308320a351a90860dca7ba