### PR TITLE
Enhance StackOverflow scraper CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Este repositório contém uma coleção de scrapers independentes para coleta de dados utilizados no treinamento de modelos de linguagem. Cada script é executado individualmente e foi criado para demonstrar como obter informações de diferentes fontes públicas, como GitHub, Reddit, Jira, etc.
 
 Todos os scrapers são apenas exemplos de uso e não possuem relação direta entre si. Para informações sobre dependências e execução, consulte a documentação em [docs/overview.md](docs/overview.md).
+
+O script `ScraperStack.py` oferece agora linha de comando para definir tags, data mínima, número de páginas e arquivo de saída.

--- a/ScraperStack.py
+++ b/ScraperStack.py
@@ -1,9 +1,12 @@
-import requests
+import argparse
 import json
-import time
 import logging
-from pydantic import BaseModel, Field
-from typing import List
+import time
+from datetime import datetime
+from typing import List, Optional
+
+import requests
+from pydantic import BaseModel
 
 # Configuração de logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -15,13 +18,25 @@ class StackOverflowData(BaseModel):
     metadata: dict
 
 class StackOverflowScraper:
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, output_file: str = "QA_stack_data.json"):
         self.base_url = "https://api.stackexchange.com/2.3"
         self.api_key = api_key
-        self.output_file = "QA_stack_data.json"
+        self.output_file = output_file
 
-    def fetch_questions(self, tags: List[str], pages: int = 5) -> List[StackOverflowData]:
+    def fetch_questions(
+        self,
+        tags: List[str],
+        pages: int = 5,
+        min_date: Optional[str] = None,
+    ) -> List[StackOverflowData]:
         data = []
+        fromdate = None
+        if min_date:
+            try:
+                dt = datetime.strptime(min_date, "%Y-%m-%d")
+                fromdate = int(dt.timestamp())
+            except ValueError:
+                logging.error(f"Data mínima inválida: {min_date}")
         for tag in tags:
             for page in range(1, pages + 1):
                 try:
@@ -32,8 +47,10 @@ class StackOverflowScraper:
                         "sort": "votes",
                         "tagged": tag,
                         "site": "stackoverflow",
-                        "key": self.api_key
+                        "key": self.api_key,
                     }
+                    if fromdate:
+                        params["fromdate"] = fromdate
                     response = requests.get(f"{self.base_url}/questions", params=params)
                     response.raise_for_status()
                     items = response.json().get("items", [])
@@ -49,7 +66,13 @@ class StackOverflowScraper:
                                 "type": "question"
                             }
                         ))
-                    time.sleep(1)  # Respeitar rate limit
+                    remaining = response.headers.get("rate_limit_remaining")
+                    if remaining is not None and remaining.isdigit() and int(remaining) == 0:
+                        wait_time = int(response.headers.get("rate_limit_reset", "1"))
+                        logging.info(f"Rate limit alcançado. Aguardando {wait_time}s...")
+                        time.sleep(wait_time)
+                    else:
+                        time.sleep(1)
                 except Exception as e:
                     logging.error(f"Erro ao coletar dados para tag {tag}, página {page}: {e}")
         return data
@@ -59,7 +82,15 @@ class StackOverflowScraper:
             json.dump([d.dict() for d in data], f, indent=2, ensure_ascii=False)
         logging.info(f"Dados salvos em {self.output_file}")
 
-# Exemplo de uso
-scraper = StackOverflowScraper(api_key= "sua_api_key_aqui")
-data = scraper.fetch_questions(tags=["python", "devops", "cloud"], pages=5)
-scraper.save_to_json(data)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Scraper de perguntas do StackOverflow")
+    parser.add_argument("--api-key", required=True, help="Chave da API do StackExchange")
+    parser.add_argument("--tags", required=True, nargs="+", help="Lista de tags")
+    parser.add_argument("--pages", type=int, default=5, help="Número de páginas a coletar")
+    parser.add_argument("--min-date", help="Data mínima no formato YYYY-MM-DD")
+    parser.add_argument("--output", default="QA_stack_data.json", help="Arquivo de saída")
+    args = parser.parse_args()
+
+    scraper = StackOverflowScraper(api_key=args.api_key, output_file=args.output)
+    data = scraper.fetch_questions(tags=args.tags, pages=args.pages, min_date=args.min_date)
+    scraper.save_to_json(data)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,7 +11,7 @@ Abaixo está um resumo do propósito de cada scraper.
 
 | Script | Finalidade |
 | ------ | ---------- |
-| `ScraperStack.py` | Coleta questões do StackOverflow via API. |
+| `ScraperStack.py` | Coleta questões do StackOverflow via API (agora com argumentos para tags, data mínima, páginas e arquivo de saída). |
 | `discord_data.py` | Exemplo de extração de mensagens do Discord. |
 | `slack_dataslack_data.py` | Exemplo de extração de mensagens do Slack. |
 | `github_issues.py` | Coleta issues de um repositório GitHub. |


### PR DESCRIPTION
## Summary
- expose CLI arguments for tags, pages, minimum date and output file
- respect `rate_limit_remaining` header
- mention new CLI options in docs and README

## Testing
- `python -m py_compile ScraperStack.py`

------
https://chatgpt.com/codex/tasks/task_e_684f05b4227483209bdc97633d4ce135