### PR TITLE
Atualiza spider de documentação

### DIFF
--- a/framework_docs_spider.py
+++ b/framework_docs_spider.py
@@ -1,11 +1,23 @@
 import scrapy
 from scrapy.crawler import CrawlerProcess
+import argparse
 import json
 import logging
 from pydantic import BaseModel
-from typing import List
+from typing import List, Dict
+from urllib.parse import urlparse, urljoin
 
 logging.basicConfig(level=logging.INFO)
+
+# Projetos suportados e respectivas URLs base
+PROJECT_URLS: Dict[str, str] = {
+    "kubernetes": "https://kubernetes.io/docs/",
+    "terraform": "https://developer.hashicorp.com/terraform/docs",
+    "huggingface": "https://huggingface.co/docs",
+}
+
+# Limite de profundidade dos links seguidos
+DEPTH_LIMIT = 2
 
 class FrameworkDocsData(BaseModel):
     id: str
@@ -14,11 +26,12 @@ class FrameworkDocsData(BaseModel):
 
 class FrameworkDocsSpider(scrapy.Spider):
     name = "framework_docs_spider"
-    start_urls = [
-        "https://kubernetes.io/docs/",
-        "https://developer.hashicorp.com/terraform/docs",
-        "https://huggingface.co/docs"
-    ]
+
+    def __init__(self, base_url: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_urls = [base_url]
+        self.allowed_domains = [urlparse(base_url).netloc]
+        self.base_url = base_url.rstrip("/")
 
     def parse(self, response):
         data = []
@@ -37,17 +50,22 @@ class FrameworkDocsSpider(scrapy.Spider):
                         "type": self.classify_document(content, response.url)
                     }
                 ))
-        self.save_to_json(data, f"framework_docs_{response.url.split('/')[2]}.json")
+        self.save_to_json(data, f"framework_docs_{urlparse(self.base_url).netloc}.json")
+
         for href in response.css("a::attr(href)").getall():
-            if href.startswith("/"):
-                yield response.follow(href, callback=self.parse)
+            abs_url = urljoin(response.url, href)
+            if abs_url.startswith(self.base_url):
+                yield response.follow(abs_url, callback=self.parse)
 
     def classify_document(self, content: str, url: str) -> str:
-        if "setup" in url.lower() or "installation" in content.lower():
+        """Classifica o tipo de documento conforme palavras-chave."""
+        url = url.lower()
+        content = content.lower()
+        if "setup" in url or "installation" in content:
             return "deployment_guide"
-        elif "api" in url.lower() or "endpoint" in content.lower():
+        if "api" in url or "endpoint" in content:
             return "api_documentation"
-        elif "monitoring" in url.lower() or "metrics" in content.lower():
+        if "monitor" in url or "metric" in content:
             return "monitoring_guide"
         return "documentation"
 
@@ -62,11 +80,23 @@ class FrameworkDocsSpider(scrapy.Spider):
             json.dump(output, f, indent=2, ensure_ascii=False)
         logging.info(f"Dados salvos em {filename}")
 
-# Executar o crawler
-process = CrawlerProcess(settings={
-    "FEEDS": {},
-    "USER_AGENT": "Mozilla/5.0",
-    "DOWNLOAD_DELAY": 2,
-})
-process.crawl(FrameworkDocsSpider)
-process.start()
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Spider para documentações de frameworks")
+    parser.add_argument("--project", choices=list(PROJECT_URLS.keys()), help="Projeto conhecido a ser coletado")
+    parser.add_argument("--base-url", help="URL base personalizada")
+    parser.add_argument("--delay", type=int, default=2, help="Delay entre requisições")
+    parser.add_argument("--user-agent", default="Mozilla/5.0", help="User-Agent para o crawler")
+    args = parser.parse_args()
+
+    base_url = args.base_url or PROJECT_URLS.get(args.project)
+    if not base_url:
+        parser.error("Informe --project ou --base-url")
+
+    process = CrawlerProcess(settings={
+        "FEEDS": {},
+        "USER_AGENT": args.user_agent,
+        "DOWNLOAD_DELAY": args.delay,
+        "DEPTH_LIMIT": DEPTH_LIMIT,
+    })
+    process.crawl(FrameworkDocsSpider, base_url=base_url)
+    process.start()


### PR DESCRIPTION
## Summary
- refatora `framework_docs_spider.py`
  - permite escolher projeto ou URL
  - limita profundidade via `DEPTH_LIMIT` e segue links só do projeto
  - define `CrawlerProcess` em `__main__` e adiciona opções de delay e user-agent
  - padroniza função de classificação

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f05b6ac708320874d9ef2bbd31f43